### PR TITLE
Represent placeholder data according to its php type vasa-c/go-db#61

### DIFF
--- a/goDB/Compat.php
+++ b/goDB/Compat.php
@@ -56,6 +56,7 @@ class Compat
      */
     private static $opts = array(
         'null' => true,
+        'types' => true,
     );
 
     /**

--- a/goDB/Helpers/Templater.php
+++ b/goDB/Helpers/Templater.php
@@ -173,7 +173,7 @@ class Templater
     }
 
     /**
-     * ?, ?string, ?scalar
+     * ?, ?scalar
      *
      * @param mixed $value
      * @param array $modifiers
@@ -185,6 +185,24 @@ class Templater
             throw new DataInvalidFormat('', 'required scalar given');
         }
         return $this->valueModification($value, $modifiers);
+    }
+    
+    /**
+     * ?string
+     * @param mixed $value
+     * @param array $modifiers
+     * @throws DataInvalidFormat
+     * @return string
+     */
+    protected function replacementSTRING($value, array $modifiers)
+    {
+        if (is_array($value)) {
+            throw new DataInvalidFormat('', 'required scalar given');
+        }
+        if (($modifiers['n'] || Compat::getOpt('types')) && is_null($value)) {
+            return $this->implementation->reprNULL($this->connection);
+        }
+        return $this->implementation->reprString($this->connection, $value);
     }
 
     /**

--- a/goDB/Helpers/Templater.php
+++ b/goDB/Helpers/Templater.php
@@ -167,8 +167,6 @@ class Templater
                 return $this->implementation->reprFloat($this->connection, $value);
             } elseif ($type === 'boolean') {
                 return $this->implementation->reprBool($this->connection, $value);
-            } elseif ($type === 'NULL') {
-                return $this->implementation->reprNULL($this->connection);
             }
         }
         return $this->implementation->reprString($this->connection, $value);

--- a/goDB/Implementations/Pgsql.php
+++ b/goDB/Implementations/Pgsql.php
@@ -154,6 +154,14 @@ final class Pgsql extends Base
     /**
      * {@inheritdoc}
      */
+    public function reprBool($connection, $value)
+    {
+        return $value ? 'true' : 'false';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function reprField($connection, $value)
     {
         return '"' . str_replace('"', '""', $value) . '"';

--- a/goDB/_config/placeholders.php
+++ b/goDB/_config/placeholders.php
@@ -14,7 +14,7 @@ return array(
 
     /* The list of long synonyms */
     'longs' => array(
-        'string' => '',
+        'string' => 'string',
         'scalar' => '',
         'list'   => 'l',
         'set'    => 's',

--- a/tests/CompatTest.php
+++ b/tests/CompatTest.php
@@ -28,20 +28,26 @@ final class CompatTest extends \PHPUnit_Framework_TestCase
     public function testSetOpt()
     {
         $db = DB::create(['host' => 'localhost'], 'test');
-        $pattern = 'INSERT ?, ?, ?i, ?n, ?in, ?s, ?sn';
-        $data = [2, null, null, null, null, ['x' => null], ['y' => null]];
-        $expectedDef = 'INSERT 2, NULL, NULL, NULL, NULL, `x`=NULL, `y`=NULL';
+        $pattern = 'INSERT ?, ?string, ?, ?i, ?n, ?in, ?s, ?sn';
+        $data = [2, null, null, null, null, null, ['x' => null], ['y' => null]];
+        $expectedDef = 'INSERT 2, NULL, NULL, NULL, NULL, NULL, `x`=NULL, `y`=NULL';
         $this->assertSame($expectedDef, $db->makeQuery($pattern, $data));
         Compat::setOpt('null', false);
         Compat::setOpt('types', false);
-        $expectedOld = 'INSERT "2", "", 0, NULL, NULL, `x`="", `y`=NULL';
+        $expectedOld = 'INSERT "2", "", "", 0, NULL, NULL, `x`="", `y`=NULL';
         $this->assertSame($expectedOld, $db->makeQuery($pattern, $data));
         Compat::setOpt('null', true);
         Compat::setOpt('types', false);
-        $this->assertSame('INSERT "2", NULL, NULL, NULL, NULL, `x`=NULL, `y`=NULL', $db->makeQuery($pattern, $data));
+        $this->assertSame(
+            'INSERT "2", NULL, NULL, NULL, NULL, NULL, `x`=NULL, `y`=NULL',
+            $db->makeQuery($pattern, $data)
+        );
         Compat::setOpt('null', false);
         Compat::setOpt('types', true);
-        $this->assertSame('INSERT 2, NULL, NULL, NULL, NULL, `x`=NULL, `y`=NULL', $db->makeQuery($pattern, $data));
+        $this->assertSame(
+            'INSERT 2, NULL, NULL, NULL, NULL, NULL, `x`=NULL, `y`=NULL',
+            $db->makeQuery($pattern, $data)
+        );
         Compat::setOpt('null', true);
         Compat::setOpt('types', true);
         $this->assertSame($expectedDef, $db->makeQuery($pattern, $data));

--- a/tests/Helpers/Fetchers/ArrTest.php
+++ b/tests/Helpers/Fetchers/ArrTest.php
@@ -91,7 +91,6 @@ class ArrTest extends \PHPUnit_Framework_TestCase
             25 => (object)array('id' => 3, 'a' => 25, 'b' => null),
         );
         $this->assertEquals($expected, $this->fetcher->objects('a'));
-
     }
 
     /**

--- a/tests/Helpers/ParserPHTest.php
+++ b/tests/Helpers/ParserPHTest.php
@@ -47,7 +47,7 @@ class ParserPHTest extends \PHPUnit_Framework_TestCase
             array('c', 'c', 'n'),
             array('e', 'e', 'n'),
             array('q', 'q', 'n'),
-            array('string', '', 'n'),
+            array('string', 'string', 'n'),
             array('scalar', '', 'n'),
             array('list', 'l', 'n'),
             array('set', 's', 'n'),

--- a/tests/Helpers/Templater/ListTest.php
+++ b/tests/Helpers/Templater/ListTest.php
@@ -22,17 +22,17 @@ final class ListTest extends Base
             'short' => [
                 'INSERT INTO `table` VALUES (?l)',
                 [$list],
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
             ],
             'full' => [
                 'INSERT INTO `table` VALUES (?list)',
                 [$list],
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
             ],
             'null' => [
                 'INSERT INTO `table` VALUES (?ln)',
                 [$list],
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
             ],
             'int' => [
                 'INSERT INTO `table` VALUES (?li)',

--- a/tests/Helpers/Templater/ScalarTest.php
+++ b/tests/Helpers/Templater/ScalarTest.php
@@ -44,6 +44,16 @@ final class ScalarTest extends Base
                 $data,
                 'INSERT INTO `table` VALUES (0, 1, NULL, 3.5, 2.5)',
             ],
+            'string' => [
+                'INSERT INTO `table` VALUES (?string, ?string, ?string, ?string, ?string)',
+                $data,
+                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5")',
+            ],
+            'string-null' => [
+                'INSERT INTO `table` VALUES (?string-null, ?string-null, ?string-null, ?string-null, ?string-null)',
+                $data,
+                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5")',
+            ],
             'full' => [
                 'INSERT INTO `table` VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int-null, ?scalar-float)',
                 $data,

--- a/tests/Helpers/Templater/ScalarTest.php
+++ b/tests/Helpers/Templater/ScalarTest.php
@@ -17,32 +17,37 @@ final class ScalarTest extends Base
      */
     public function providerTemplater()
     {
-        $data = ['str"ing', 1, null, '3.5'];
+        $data = ['str"ing', 1, null, '3.5', 2.5];
         return [
             'escape' => [
-                'INSERT INTO `table` VALUES (?, ?scalar, ?, ?string)',
+                'INSERT INTO `table` VALUES (?, ?scalar, ?, ?string, ?)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5", 2.5)',
             ],
             'null' => [
-                'INSERT INTO `table` VALUES (?null, ?null, ?null, ?null)',
+                'INSERT INTO `table` VALUES (?null, ?null, ?null, ?null, ?null)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5", 2.5)',
             ],
             'int' => [
-                'INSERT INTO `table` VALUES (?i, ?i, ?i, ?i)',
+                'INSERT INTO `table` VALUES (?i, ?i, ?i, ?i, ?i)',
                 $data,
-                'INSERT INTO `table` VALUES (0, 1, NULL, 3)',
+                'INSERT INTO `table` VALUES (0, 1, NULL, 3, 2)',
             ],
             'int-null' => [
-                'INSERT INTO `table` VALUES (?in, ?in, ?in, ?in)',
+                'INSERT INTO `table` VALUES (?in, ?in, ?in, ?in, ?in)',
                 $data,
-                'INSERT INTO `table` VALUES (0, 1, NULL, 3)',
+                'INSERT INTO `table` VALUES (0, 1, NULL, 3, 2)',
+            ],
+            'float' => [
+                'INSERT INTO `table` VALUES (?f, ?f, ?f, ?f, ?f)',
+                $data,
+                'INSERT INTO `table` VALUES (0, 1, NULL, 3.5, 2.5)',
             ],
             'full' => [
-                'INSERT INTO `table` VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int-null)',
+                'INSERT INTO `table` VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int-null, ?scalar-float)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, 3)',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, 3, 2.5)',
             ],
         ];
     }

--- a/tests/Helpers/Templater/ScalarTest.php
+++ b/tests/Helpers/Templater/ScalarTest.php
@@ -22,12 +22,12 @@ final class ScalarTest extends Base
             'escape' => [
                 'INSERT INTO `table` VALUES (?, ?scalar, ?, ?string)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
             ],
             'null' => [
                 'INSERT INTO `table` VALUES (?null, ?null, ?null, ?null)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5")',
             ],
             'int' => [
                 'INSERT INTO `table` VALUES (?i, ?i, ?i, ?i)',

--- a/tests/Helpers/Templater/ValuesTest.php
+++ b/tests/Helpers/Templater/ValuesTest.php
@@ -25,12 +25,12 @@ final class ValuesTest extends Base
             'values' => [
                 'INSERT INTO `table` VALUES ?values;',
                 [$values],
-                'INSERT INTO `table` VALUES ("0", "1", "2"), ("one", NULL, "three")',
+                'INSERT INTO `table` VALUES (0, 1, 2), ("one", NULL, "three")',
             ],
             'null' => [
                 'INSERT INTO `table` VALUES ?vn',
                 [$values],
-                'INSERT INTO `table` VALUES ("0", "1", "2"), ("one", NULL, "three")',
+                'INSERT INTO `table` VALUES (0, 1, 2), ("one", NULL, "three")',
             ],
             'int' => [
                 'INSERT INTO `table` VALUES ?values-int',

--- a/tests/Real/Mysql/MysqlTest.php
+++ b/tests/Real/Mysql/MysqlTest.php
@@ -62,6 +62,9 @@ class MysqlTest extends Base
 
         $trickyName = 'qu`ote"d na\'me';
         $this->assertEquals('str', $db->query("SELECT 'str' as ?c", array($trickyName))->el($trickyName));
+        
+        $this->assertEquals('1', $db->makeQuery('?', array(true)));
+        $this->assertEquals('0', $db->makeQuery('?', array(false)));
     }
 
     /**

--- a/tests/Real/Mysqlold/MysqloldTest.php
+++ b/tests/Real/Mysqlold/MysqloldTest.php
@@ -62,6 +62,9 @@ class MysqloldTest extends Base
 
         $trickyName = 'qu`ote"d na\'me';
         $this->assertEquals('str', $db->query("SELECT 'str' as ?c", array($trickyName))->el($trickyName));
+        
+        $this->assertEquals('1', $db->makeQuery('?', array(true)));
+        $this->assertEquals('0', $db->makeQuery('?', array(false)));
     }
 
     public function testErrorConnect()

--- a/tests/Real/Pgsql/PgsqlTest.php
+++ b/tests/Real/Pgsql/PgsqlTest.php
@@ -75,6 +75,9 @@ class PgsqlTest extends Base
 
         $trickyName = 'qu`ote"d na\'me';
         $this->assertEquals('str', $db->query("SELECT 'str' as ?c", array($trickyName))->el($trickyName));
+        
+        $this->assertEquals('true', $db->makeQuery('?', array(true)));
+        $this->assertEquals('false', $db->makeQuery('?', array(false)));
     }
 
     public function testErrorConnect()

--- a/tests/Real/Sqlite/SqliteTest.php
+++ b/tests/Real/Sqlite/SqliteTest.php
@@ -64,6 +64,9 @@ class SqliteTest extends Base
 
         $trickyName = 'qu`ote"d na\'me';
         $this->assertEquals('str', $db->query("SELECT 'str' as ?c", array($trickyName))->el($trickyName));
+        
+        $this->assertEquals('1', $db->makeQuery('?', array(true)));
+        $this->assertEquals('0', $db->makeQuery('?', array(false)));
     }
 
     public function testErrorConnect()

--- a/tests/TableTest.php
+++ b/tests/TableTest.php
@@ -104,8 +104,6 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $table->update(array('id' => $col), array('id'=>5));
         $this->assertSame(1, $table->getCount(null, array('id' => 6)));
-
-
     }
 
     /**


### PR DESCRIPTION
Что сделано:
Плейсхолдеры, для которых не указан модификатор int, float или bool, подставляются в соответствии с типом данных. Если же модификатор указан, то значение приводится к указанному типу, или, если значение равно null, вставляется NULL.

Необходимые изменения в документации:
1. https://github.com/vasa-c/go-db/wiki/Compat
Новый параметр `types`

`types`
Представлять данные в соответствии с типом данных PHP, если не указан модификтор.
По умолчанию - `true`. Если установлен в `true`, то параметр `null` не имеет эффекта.
1. https://github.com/vasa-c/go-db/wiki/placeholders
   "Плейсхолдеры для вставки данных
   Строка (?, ?string, ?scalar)
   Данные вставляются, как обычные строки."

Теперь не актуально, данные вставляются в соответсвии с типом.
~~Плейсхолдер `?string` теперь сбивает с толку~~ :)
