### PR TITLE
?string now modifier. New modifier ?hex for hexadecimal strings as in…

### DIFF
--- a/goDB/Helpers/Templater.php
+++ b/goDB/Helpers/Templater.php
@@ -152,6 +152,12 @@ class Templater
                 return $this->implementation->reprNULL($this->connection);
             }
         }
+        if ($modifiers['h']) {
+            return $this->implementation->reprHexadecimal($this->connection, $value);
+        }
+        if ($modifiers['r']) {
+            return $this->implementation->reprString($this->connection, $value);
+        }
         if ($modifiers['i']) {
             return $this->implementation->reprInt($this->connection, $value);
         } elseif ($modifiers['f']) {
@@ -185,24 +191,6 @@ class Templater
             throw new DataInvalidFormat('', 'required scalar given');
         }
         return $this->valueModification($value, $modifiers);
-    }
-    
-    /**
-     * ?string
-     * @param mixed $value
-     * @param array $modifiers
-     * @throws DataInvalidFormat
-     * @return string
-     */
-    protected function replacementSTRING($value, array $modifiers)
-    {
-        if (is_array($value)) {
-            throw new DataInvalidFormat('', 'required scalar given');
-        }
-        if (($modifiers['n'] || Compat::getOpt('types')) && is_null($value)) {
-            return $this->implementation->reprNULL($this->connection);
-        }
-        return $this->implementation->reprString($this->connection, $value);
     }
 
     /**

--- a/goDB/Implementations/Base.php
+++ b/goDB/Implementations/Base.php
@@ -258,6 +258,18 @@ abstract class Base
     }
 
     /**
+     * Represents a string as a hexadecimal literal
+     *
+     * @param $connection
+     * @param $value
+     * @return string
+     */
+    public function reprHexadecimal($connection, $value)
+    {
+        return 'x\''.$this->escapeString($connection, $value).'\'';
+    }
+
+    /**
      * Represents a integer number as a data
      *
      * @param mixed $connection

--- a/goDB/_config/placeholders.php
+++ b/goDB/_config/placeholders.php
@@ -14,7 +14,6 @@ return array(
 
     /* The list of long synonyms */
     'longs' => array(
-        'string' => 'string',
         'scalar' => '',
         'list'   => 'l',
         'set'    => 's',
@@ -30,7 +29,7 @@ return array(
 
     /* The list of modifiers (the main short form) */
     'modifiers' => array(
-        'n', 'i', 'f', 'b',
+        'n', 'i', 'f', 'b', 'h', 'r'
     ),
 
     /* The list of long synonyms of modifiers */
@@ -39,5 +38,7 @@ return array(
         'int'   => 'i',
         'float' => 'f',
         'bool'  => 'b',
+        'hex'   => 'h',
+        'string' => 'r',
     ),
 );

--- a/tests/Helpers/ParserPHTest.php
+++ b/tests/Helpers/ParserPHTest.php
@@ -40,6 +40,7 @@ class ParserPHTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('', '', 'n'),
+            array('h', '', 'hn'),
             array('l', 'l', 'n'),
             array('s', 's', 'n'),
             array('v', 'v', 'n'),
@@ -47,8 +48,9 @@ class ParserPHTest extends \PHPUnit_Framework_TestCase
             array('c', 'c', 'n'),
             array('e', 'e', 'n'),
             array('q', 'q', 'n'),
-            array('string', 'string', 'n'),
+            array('string', '', 'rn'),
             array('scalar', '', 'n'),
+            array('hex', '', 'hn'),
             array('list', 'l', 'n'),
             array('set', 's', 'n'),
             array('values', 'v', 'n'),

--- a/tests/Helpers/Templater/ListTest.php
+++ b/tests/Helpers/Templater/ListTest.php
@@ -39,6 +39,11 @@ final class ListTest extends Base
                 [$list],
                 'INSERT INTO `table` VALUES (0, 1, NULL, 3)',
             ],
+            'string' => [
+                'INSERT INTO `table` VALUES (?list-string)',
+                [$list],
+                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5")',
+            ],
             'mixed' => [
                 'INSERT INTO `table` VALUES (?lin)',
                 [$list],

--- a/tests/Helpers/Templater/ScalarTest.php
+++ b/tests/Helpers/Templater/ScalarTest.php
@@ -50,12 +50,14 @@ final class ScalarTest extends Base
                 'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5", "28f7dc7206a1")',
             ],
             'string-null' => [
-                'INSERT INTO `table` VALUES (?string-null, ?string-null, ?string-null, ?string-null, ?string-null, ?string-null)',
+                'INSERT INTO `table`'
+                    . ' VALUES (?string-null, ?string-null, ?string-null, ?string-null, ?string-null, ?string-null)',
                 $data,
                 'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5", "28f7dc7206a1")',
             ],
             'full' => [
-                'INSERT INTO `table` VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int, ?scalar-float, ?scalar-hex)',
+                'INSERT INTO `table`'
+                    . ' VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int, ?scalar-float, ?scalar-hex)',
                 $data,
                 'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, 3, 2.5, x\'28f7dc7206a1\')',
             ],

--- a/tests/Helpers/Templater/ScalarTest.php
+++ b/tests/Helpers/Templater/ScalarTest.php
@@ -17,47 +17,52 @@ final class ScalarTest extends Base
      */
     public function providerTemplater()
     {
-        $data = ['str"ing', 1, null, '3.5', 2.5];
+        $data = ['str"ing', 1, null, '3.5', 2.5, '28f7dc7206a1'];
         return [
             'escape' => [
-                'INSERT INTO `table` VALUES (?, ?scalar, ?, ?string, ?)',
+                'INSERT INTO `table` VALUES (?, ?scalar, ?, ?string, ?, ?)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5", 2.5)',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5", 2.5, "28f7dc7206a1")',
             ],
             'null' => [
-                'INSERT INTO `table` VALUES (?null, ?null, ?null, ?null, ?null)',
+                'INSERT INTO `table` VALUES (?null, ?null, ?null, ?null, ?null, ?null)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5", 2.5)',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, "3.5", 2.5, "28f7dc7206a1")',
             ],
             'int' => [
-                'INSERT INTO `table` VALUES (?i, ?i, ?i, ?i, ?i)',
+                'INSERT INTO `table` VALUES (?i, ?i, ?i, ?i, ?i, ?i)',
                 $data,
-                'INSERT INTO `table` VALUES (0, 1, NULL, 3, 2)',
+                'INSERT INTO `table` VALUES (0, 1, NULL, 3, 2, 28)',
             ],
             'int-null' => [
-                'INSERT INTO `table` VALUES (?in, ?in, ?in, ?in, ?in)',
+                'INSERT INTO `table` VALUES (?in, ?in, ?in, ?in, ?in, ?in)',
                 $data,
-                'INSERT INTO `table` VALUES (0, 1, NULL, 3, 2)',
+                'INSERT INTO `table` VALUES (0, 1, NULL, 3, 2, 28)',
             ],
             'float' => [
-                'INSERT INTO `table` VALUES (?f, ?f, ?f, ?f, ?f)',
+                'INSERT INTO `table` VALUES (?f, ?f, ?f, ?f, ?f, ?f)',
                 $data,
-                'INSERT INTO `table` VALUES (0, 1, NULL, 3.5, 2.5)',
+                'INSERT INTO `table` VALUES (0, 1, NULL, 3.5, 2.5, 28)',
             ],
             'string' => [
-                'INSERT INTO `table` VALUES (?string, ?string, ?string, ?string, ?string)',
+                'INSERT INTO `table` VALUES (?string, ?string, ?string, ?string, ?string, ?string)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5", "28f7dc7206a1")',
             ],
             'string-null' => [
-                'INSERT INTO `table` VALUES (?string-null, ?string-null, ?string-null, ?string-null, ?string-null)',
+                'INSERT INTO `table` VALUES (?string-null, ?string-null, ?string-null, ?string-null, ?string-null, ?string-null)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5")',
+                'INSERT INTO `table` VALUES ("str\"ing", "1", NULL, "3.5", "2.5", "28f7dc7206a1")',
             ],
             'full' => [
-                'INSERT INTO `table` VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int-null, ?scalar-float)',
+                'INSERT INTO `table` VALUES (?string, ?scalar-int, ?scalar-null, ?scalar-int, ?scalar-float, ?scalar-hex)',
                 $data,
-                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, 3, 2.5)',
+                'INSERT INTO `table` VALUES ("str\"ing", 1, NULL, 3, 2.5, x\'28f7dc7206a1\')',
+            ],
+            'hex' => [
+                'INSERT INTO `table` VALUES (?h, ?h, ?h, ?hn, ?hex, ?scalar-hex)',
+                $data,
+                "INSERT INTO `table` VALUES (x'str\\\"ing', x'1', NULL, x'3.5', x'2.5', x'28f7dc7206a1')",
             ],
         ];
     }


### PR DESCRIPTION
1) string сделал модификатором, как и другие типы (int, float ...). теперь можно использовать для списков: ?list-string, ?values-string-null
2) Добавил новый модификатор ?hex. Если строка содержит число в шестнадцатеричном формате, данный модификатор экранирует и приводит к виду x'0ffe23f3' (общий формат для postgresql, mysql и sqlite), когда нужно сохранить в поле binary, blob или целочисленные.
В нашем проекте активно используются ключи полученные от UUID (32 шестнадцатеричных символа) но для сокращения потребляемого места, используем поля типа binary(16)
самый простой способ сохранения таких данных - hex2bin($userId) и результат подставлять в запрос как строку. Но в таком виде очень сложно анализировать запросы, и мониторить через процесс-лист.