### PR TITLE
Указание модификаторов, для элементов данных плейсхолдеров values, list и set

### DIFF
--- a/goDB/Exceptions/SubDataInvalidFormat.php
+++ b/goDB/Exceptions/SubDataInvalidFormat.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package go\DB
+ */
+
+namespace go\DB\Exceptions;
+
+final class SubDataInvalidFormat extends Data
+{
+    /**
+     * @param int $placeholder
+     * @param int $message
+     * @param Logic $previous
+     */
+    public function __construct($placeholder, $message, $previous = null)
+    {
+        $message = 'Invalid sub data for ?' . $placeholder . ': ' . $message;
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/goDB/Helpers/Templater.php
+++ b/goDB/Helpers/Templater.php
@@ -264,7 +264,7 @@ class Templater
             }
             if (!empty($elementModifiers)) {
                 if (!isset($elementModifiers[$k])) {
-                    throw new DataInvalidFormat('set', 'No modifier for key: ' . $k);
+                    throw new DataInvalidFormat('list', 'No modifier for key: ' . $k);
                 }
                 $elementMod = $elementModifiers[$k];
             } else {
@@ -298,18 +298,17 @@ class Templater
                     $element = $this->replacementC($element, $modifiers);
                 }
             } else {
-                if (is_int($element) && !isset($elementModifiers[$col])) {
-                    $element = $this->implementation->reprInt($this->connection, $element);
-                } else {
-                    if (!empty($elementModifiers)) {
-                        if (!isset($elementModifiers[$col])) {
-                            throw new DataInvalidFormat('set', 'No modifier for col: ' . $col);
-                        }
-                        $elementMod = $elementModifiers[$col];
-                    } else {
-                        $elementMod = $modifiers;
+                if (!empty($elementModifiers)) {
+                    if (!isset($elementModifiers[$col])) {
+                        throw new DataInvalidFormat('set', 'No modifier for col: ' . $col);
                     }
-                    $element = $this->valueModification($element, $elementMod);
+                    $element = $this->valueModification($element, $elementModifiers[$col]);
+                } else {
+                    if (is_int($element)) {
+                        $element = $this->implementation->reprInt($this->connection, $element);
+                    } else {
+                        $element = $this->valueModification($element, $modifiers);
+                    }
                 }
             }
             $set[] = $key.'='.$element;

--- a/tests/Helpers/Templater/ExceptionsTest.php
+++ b/tests/Helpers/Templater/ExceptionsTest.php
@@ -236,4 +236,62 @@ final class ExceptionsTest extends BaseTemplater
             ],
         ];
     }
+
+    /**
+     * @dataProvider providerExceptionSubDataInvalidFormat
+     * @param string $placeholder
+     * @param mixed $data
+     * @param string $exceptionClass
+     * @param string $message
+     */
+    public function testExceptionSubDataInvalidFormat($placeholder, $data, $exceptionClass, $message)
+    {
+        $pattern = '?'.$placeholder;
+        $data = [$data];
+        $templater = $this->createTemplater($pattern, $data);
+        $this->setExpectedException($exceptionClass, $message);
+        $templater->parse();
+    }
+
+    public function providerExceptionSubDataInvalidFormat()
+    {
+        return [
+            'type' => [
+                'v[?i, ?set-int]',
+                [1, 2],
+                'go\DB\Exceptions\SubDataInvalidFormat',
+                'Only modifiers can be used. Found type: s',
+            ],
+            'internal' => [
+                'l[?i, ?wtf]',
+                [1, 2],
+                'go\DB\Exceptions\SubDataInvalidFormat',
+                'Invalid sub data for ?l: Unknown placeholder "wtf"',
+            ],
+            'mixedSubPlaceholder' => [
+                'l[?i, ?i:foo]',
+                [1, 2],
+                'go\DB\Exceptions\SubDataInvalidFormat',
+                'Invalid sub data for ?l: Mixed placeholder "?i:foo"',
+            ],
+            'mixedSubPlaceholder2' => [
+                'v[?i:bar, ?i]',
+                [1, 2],
+                'go\DB\Exceptions\SubDataInvalidFormat',
+                'Invalid sub data for ?v: Mixed placeholder "?i"',
+            ],
+            'listElementModifierNotSet' => [
+                'l[?i, ?i]',
+                [1, 2, 3],
+                'go\DB\Exceptions\DataInvalidFormat',
+                'Data for ?list has invalid format: "No modifier for key: 2"',
+            ],
+            'setElementModifierNotSet' => [
+                's[?i:foo, ?i:baZ]',
+                ['foo' => 1, 'bar' => 2],
+                'go\DB\Exceptions\DataInvalidFormat',
+                'Data for ?set has invalid format: "No modifier for col: bar"',
+            ],
+        ];
+    }
 }

--- a/tests/Helpers/Templater/ListTest.php
+++ b/tests/Helpers/Templater/ListTest.php
@@ -49,6 +49,11 @@ final class ListTest extends Base
                 [$list],
                 'INSERT INTO `table` VALUES (0, 1, NULL, 3)',
             ],
+            'subtype' => [
+                'INSERT INTO `table` VALUES (?l[?int, ?string, ?n, ?int])',
+                [$list],
+                'INSERT INTO `table` VALUES (0, "1", NULL, 3)',
+            ],
         ];
     }
 }

--- a/tests/Helpers/Templater/SetTest.php
+++ b/tests/Helpers/Templater/SetTest.php
@@ -28,6 +28,11 @@ final class SetTest extends Base
                 [$set],
                 'INSERT INTO `table` SET `s`="str\"ing", `d`="3.5", `n`=NULL',
             ],
+            'subset' => [
+                'INSERT INTO `table` SET ?s[?string:s, ?int:d, ?null:n]',
+                [$set],
+                'INSERT INTO `table` SET `s`="str\"ing", `d`=3, `n`=NULL',
+            ],
             'null' => [
                 'INSERT INTO `table` SET ?set-null',
                 [$set],

--- a/tests/Helpers/Templater/ValuesTest.php
+++ b/tests/Helpers/Templater/ValuesTest.php
@@ -27,6 +27,11 @@ final class ValuesTest extends Base
                 [$values],
                 'INSERT INTO `table` VALUES (0, 1, 2), ("one", NULL, "three")',
             ],
+            'subset' => [
+                'INSERT INTO `table` VALUES ?values[?string, ?int-null, ?i]',
+                [$values],
+                'INSERT INTO `table` VALUES ("0", 1, 2), ("one", NULL, 0)',
+            ],
             'null' => [
                 'INSERT INTO `table` VALUES ?vn',
                 [$values],


### PR DESCRIPTION
Сори. я случайно создал пул-реквест. Не обратил внимание, что предлагает мержить в твою ветку .
Но может и здесь будет полезно.
Суть в следующем:
Для плейсхолдера ?values нужна возможность указать модификаторы для каждого элемета массива.
Решил немного доработать синтаксис плейсхолдеров, и теперь в квадратных скобках можно указывать модификаторы для элементов массива.
на примере теста
```
 // tests/Helpers/Templater/ValuesTest.php
 $values = [
     [0, 1, 2],
     ['one', null, 'three'],
 ];
 // ожидаемый результат
 'subset' => [
     'INSERT INTO table VALUES ?values[?string, ?int-null, ?i]',
     [$values],
     'INSERT INTO table VALUES ("0", 1, 2), ("one", NULL, 0)',
 ]
```
Работает для типов values, list и set
при этом для set обязательно именование прейсхоледеров, для ассоциации с полями
```
'subset' => [
    'INSERT INTO `table` SET ?s[?string:foo, ?int:bar, ?null:baz]',
    [$set],
    'INSERT INTO `table` SET `foo`="str\"ing", `bar`=3, `baz`=NULL',
],
```